### PR TITLE
Balancer v3 labels: include reCLAMM Pools

### DIFF
--- a/dbt_subprojects/dex/models/_projects/balancer/labels/arbitrum/labels_balancer_v3_pools_arbitrum.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/arbitrum/labels_balancer_v3_pools_arbitrum.sql
@@ -47,6 +47,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_arbitrum', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_arbitrum', 'StablePoolFactory_call_create') }} cc

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/base/labels_balancer_v3_pools_base.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/base/labels_balancer_v3_pools_base.sql
@@ -47,6 +47,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_base', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_base', 'StablePoolFactory_call_create') }} cc

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/ethereum/labels_balancer_v3_pools_ethereum.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/ethereum/labels_balancer_v3_pools_ethereum.sql
@@ -47,6 +47,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_ethereum', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_ethereum', 'StablePoolFactory_call_create') }} cc

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/gnosis/labels_balancer_v3_pools_gnosis.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/gnosis/labels_balancer_v3_pools_gnosis.sql
@@ -47,6 +47,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_gnosis', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_gnosis', 'StablePoolFactory_call_create') }} cc

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/hyperevm/labels_balancer_v3_pools_hyperevm.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/hyperevm/labels_balancer_v3_pools_hyperevm.sql
@@ -46,6 +46,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_hyperevm', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_hyperevm', 'StablePoolFactory_call_create') }} cc

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/monad/labels_balancer_v3_pools_monad.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/monad/labels_balancer_v3_pools_monad.sql
@@ -47,6 +47,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_monad', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_monad', 'StablePoolFactory_call_create') }} cc


### PR DESCRIPTION
# Add Reclamm Balancer v3 pools to chain labels

## Summary

This change extends the Balancer v3 pool label spells so **Reclamm** pools are included wherever the `ReclammPoolFactory_call_create` decoded table exists for that chain.

## What changed

For each affected model, a new `UNION ALL` branch:

- Joins `token_data` to `ReclammPoolFactory_call_create` on `output_pool`
- Sets `pool_type = 'reclamm'`
- Reuses the same token/weight pattern as other non-weighted factory branches (zero weights, tokens unnested from `token_data`)

## Chains

- Arbitrum
- Base
- Ethereum
- Gnosis
- HyperEVM
- Monad

(Model files: `labels_balancer_v3_pools_*`.)

## Notes

No other behavior is intended beyond labeling these pools consistently with existing weighted/stable factory logic.