### PR TITLE
Add 'ReclammPoolFactory_call_create' source to Balancer configurations

### DIFF
--- a/sources/balancer/arbitrum/balancer_arbitrum_sources.yml
+++ b/sources/balancer/arbitrum/balancer_arbitrum_sources.yml
@@ -233,3 +233,5 @@ sources:
       - name: LBPool_evt_GradualWeightUpdateScheduled 
 
       - name: GyroECLPPoolFactory_call_create  
+
+      - name: ReclammPoolFactory_call_create

--- a/sources/balancer/base/balancer_base_sources.yml
+++ b/sources/balancer/base/balancer_base_sources.yml
@@ -192,3 +192,5 @@ sources:
       - name: LBPool_evt_GradualWeightUpdateScheduled  
 
       - name: GyroECLPPoolFactory_call_create  
+
+      - name: ReclammPoolFactory_call_create

--- a/sources/balancer/ethereum/balancer_ethereum_sources.yml
+++ b/sources/balancer/ethereum/balancer_ethereum_sources.yml
@@ -400,3 +400,5 @@ sources:
       - name: LBPool_evt_GradualWeightUpdateScheduled  
 
       - name: GyroECLPPoolFactory_call_create  
+
+      - name: ReclammPoolFactory_call_create

--- a/sources/balancer/gnosis/balancer_gnosis_sources.yml
+++ b/sources/balancer/gnosis/balancer_gnosis_sources.yml
@@ -292,3 +292,5 @@ sources:
       - name: LBPool_evt_GradualWeightUpdateScheduled  
 
       - name: GyroECLPPoolFactory_call_create  
+
+      - name: ReclammPoolFactory_call_create

--- a/sources/balancer/hyperevm/balancer_hyperevm_sources.yml
+++ b/sources/balancer/hyperevm/balancer_hyperevm_sources.yml
@@ -49,3 +49,5 @@ sources:
       - name: LBPool_evt_GradualWeightUpdateScheduled  
 
       - name: GyroECLPPoolFactory_call_create  
+
+      - name: ReclammPoolFactory_call_create

--- a/sources/balancer/monad/balancer_monad_sources.yml
+++ b/sources/balancer/monad/balancer_monad_sources.yml
@@ -48,3 +48,5 @@ sources:
       - name: LBPool_evt_GradualWeightUpdateScheduled  
 
       - name: GyroECLPPoolFactory_call_create  
+
+      - name: ReclammPoolFactory_call_create


### PR DESCRIPTION
- Included 'ReclammPoolFactory_call_create' in the sources for Arbitrum, Base, Ethereum, Gnosis, Hyperevm, and Monad.
- Ensured consistent integration of the new pool type across multiple Balancer configurations.

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
