### PR TITLE
Update Balancer v3 pools SQL models to include 'reclamm' pool type

### DIFF
--- a/dbt_subprojects/dex/models/_projects/balancer/labels/arbitrum/labels_balancer_v3_pools_arbitrum.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/arbitrum/labels_balancer_v3_pools_arbitrum.sql
@@ -122,7 +122,7 @@ WITH token_data AS (
 SELECT 
   'arbitrum' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP') 
+  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP', 'reclamm') 
   THEN lower(pool_symbol)
     ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
     array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/base/labels_balancer_v3_pools_base.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/base/labels_balancer_v3_pools_base.sql
@@ -122,7 +122,7 @@ WITH token_data AS (
 SELECT 
   'base' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP') 
+  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP', 'reclamm') 
   THEN lower(pool_symbol)
     ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
     array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/ethereum/labels_balancer_v3_pools_ethereum.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/ethereum/labels_balancer_v3_pools_ethereum.sql
@@ -122,7 +122,7 @@ WITH token_data AS (
 SELECT 
   'ethereum' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP') 
+  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP', 'reclamm') 
   THEN lower(pool_symbol)
     ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
     array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/gnosis/labels_balancer_v3_pools_gnosis.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/gnosis/labels_balancer_v3_pools_gnosis.sql
@@ -122,7 +122,7 @@ WITH token_data AS (
 SELECT 
   'gnosis' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP') 
+  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP', 'reclamm') 
   THEN lower(pool_symbol)
     ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
     array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/hyperevm/labels_balancer_v3_pools_hyperevm.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/hyperevm/labels_balancer_v3_pools_hyperevm.sql
@@ -121,7 +121,7 @@ WITH token_data AS (
 SELECT 
   'hyperevm' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP') 
+  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP', 'reclamm') 
   THEN lower(pool_symbol)
     ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
     array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/monad/labels_balancer_v3_pools_monad.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/monad/labels_balancer_v3_pools_monad.sql
@@ -143,7 +143,7 @@ WITH token_data AS (
 SELECT 
   'monad' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP') 
+  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP', 'reclamm') 
   THEN lower(pool_symbol)
     ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
     array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/plasma/labels_balancer_v3_pools_plasma.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/plasma/labels_balancer_v3_pools_plasma.sql
@@ -122,7 +122,7 @@ WITH token_data AS (
 SELECT 
   'plasma' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP') 
+  CASE WHEN pool_type IN ('stable', 'LBP', 'ECLP', 'reclamm') 
   THEN lower(pool_symbol)
     ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
     array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))


### PR DESCRIPTION
- Modified SQL logic across multiple blockchain models (Arbitrum, Base, Ethereum, Gnosis, Hyperevm, Monad, Plasma) to incorporate 'reclamm' pool type in the CASE statement.
- Enhanced token data handling for improved categorization of Balancer v3 pools.

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
